### PR TITLE
Actually make queues out of queue defns, add concurrency limits

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -234,11 +234,13 @@ App.prototype.start = function () {
         {
         name: 'machine_creation',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 4,
             tasks: [ 'machine_create', 'machine_reprovision' ]
         },
         {
             name: 'image_import_tasks',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 4,
             tasks: [ 'image_ensure_present' ]
         },
         {
@@ -251,6 +253,7 @@ App.prototype.start = function () {
         {
             name: 'docker_tasks',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 8,
             tasks: [
                 'docker_exec',
                 'docker_copy'
@@ -275,6 +278,7 @@ App.prototype.start = function () {
         {
             name: 'machine_tasks',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 4,
             tasks: [
                 'machine_boot',
                 'machine_destroy',
@@ -294,6 +298,7 @@ App.prototype.start = function () {
             name: 'machine_images',
             expires: 60, // expire messages in this queue after a minute
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 2,
             tasks: [
                 'machine_create_image'
             ]
@@ -302,6 +307,7 @@ App.prototype.start = function () {
             name: 'image_query',
             expires: 60, // expire messages in this queue after a minute
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 2,
             logging: false,
             tasks: [
                 'image_get'
@@ -311,6 +317,7 @@ App.prototype.start = function () {
             name: 'machine_query',
             expires: 60, // expire messages in this queue after a minute
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 8,
             logging: false,
             tasks: [
                 'machine_load',
@@ -320,6 +327,7 @@ App.prototype.start = function () {
         {
             name: 'zfs_tasks',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 4,
             tasks: [
                 'zfs_create_dataset',
                 'zfs_destroy_dataset',
@@ -333,6 +341,7 @@ App.prototype.start = function () {
         {
             name: 'zfs_query',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 8,
             tasks: [
                 'zfs_get_properties',
                 'zfs_list_datasets',
@@ -343,6 +352,7 @@ App.prototype.start = function () {
         {
             name: 'fw_tasks',
             onhttpmsg: createHttpTaskDispatchFn(agent, tasksPath),
+            concurrency: 4,
             tasks: [
                 'fw_add',
                 'fw_del',

--- a/lib/task_agent/dispatch.js
+++ b/lib/task_agent/dispatch.js
@@ -16,15 +16,25 @@
 var path = require('path');
 
 function createHttpTaskDispatchFn(agent) {
-    return function (req) {
+    return function (req, cb) {
+        var now = (new Date()).getTime();
+        if (req.queue.expires && req.created &&
+                now - req.created.getTime() > req.queue.expires * 1000) {
+            req.event('error', 'Task expired');
+            req.finish();
+            return cb();
+        }
+
         var child = agent.runner.dispatch(req);
-        setupHttpChildEventHandlers(agent, child, req);
+        setupHttpChildEventHandlers(agent, child, req, cb);
     };
 }
 
-function setupHttpChildEventHandlers(agent, child, req, http) {
+function setupHttpChildEventHandlers(agent, child, req, cb, http) {
     child.on('finish', function () {
         req.finish();
+        if (cb)
+            cb();
     });
 
     child.on('progress', function (value) {
@@ -36,9 +46,11 @@ function setupHttpChildEventHandlers(agent, child, req, http) {
     });
 }
 
-function setupChildEventHandlers(agent, child, req) {
+function setupChildEventHandlers(agent, child, req, cb) {
     child.on('finish', function () {
         req.finish();
+        if (cb)
+            cb();
     });
 
     child.on('progress', function (value) {

--- a/lib/task_agent/task_agent.js
+++ b/lib/task_agent/task_agent.js
@@ -119,13 +119,7 @@ TaskAgent.prototype.startHttpService = function (defns) {
             return;
         }
 
-        var dispatch = {};
-
-        self.queueDefns.forEach(function (i) {
-            i.tasks.forEach(function (j) {
-                dispatch[j] = i.onhttpmsg;
-            });
-        });
+        var dispatch = self.queuesByTask;
 
         var value, error;
 
@@ -144,10 +138,14 @@ TaskAgent.prototype.startHttpService = function (defns) {
             }
         }
 
+        var taskq = dispatch[req.params.task];
+
         var params = {
             req_id: req.getId(),
             task: req.params.task,
             params: req.params.params,
+            queue: taskq,
+            created: (new Date()),
             finish: function () {
                 fcb();
             },
@@ -165,10 +163,8 @@ TaskAgent.prototype.startHttpService = function (defns) {
             }
         };
 
-        // NEED TO CALL DISPATCH FN WITH A "REQ" OBJECT
-        var taskfn = dispatch[req.params.task];
-        if (taskfn) {
-            dispatch[req.params.task](params);
+        if (taskq) {
+            taskq.push(params);
         } else {
             next(new restify.ResourceNotFoundError(
                 'Unknown task, \'%s\'', req.params.task));
@@ -235,7 +231,17 @@ TaskAgent.prototype.startHttpService = function (defns) {
 
 TaskAgent.prototype.useQueues = function (defns) {
     var self = this;
-    self.queueDefns = defns;
+    self.queuesByTask = {};
+    self.queues = [];
+    defns.forEach(function(defn) {
+        var queue = async.queue(defn.onhttpmsg, defn.concurrency || 1);
+        queue.name = defn.name;
+        queue.expires = defn.expires;
+        self.queues.push(queue);
+        defn.tasks.forEach(function(task) {
+            self.queuesByTask[task] = queue;
+        });
+    });
 };
 
 


### PR DESCRIPTION
async.queue should be able to do all the things we really needed ThrottledQueue to do in provisioner-agent, so instantiate one of these for each of the queue defns for task handling.

Also handles job expiry by just checking how long each item has been on the queue before actual handling starts.

The default concurrency is 1 on these new queues, to avoid future "lenth" bugs occurring by human error.

The concurrency limits on docker operations might warrant some bumping up from the numbers I've put in, especially if operations like "docker cp" are expected to be long-running. I'm not using these very much yet, so it's hard to get a good feel for what's appropriate, sorry.