### PR TITLE
AGENT-919: Remove unnecessary HTTP API routes

### DIFF
--- a/lib/task_agent/task_agent.js
+++ b/lib/task_agent/task_agent.js
@@ -184,56 +184,6 @@ TaskAgent.prototype.startHttpService = function (defns) {
         }
     });
 
-    server.get('/tasks', function listTasks(req, res, next) {
-        var opts = {};
-
-        if (req.params.status) {
-            opts.status = req.params.status;
-        }
-        var history = getHistory(opts);
-        res.send(200, history);
-        next();
-    });
-
-    function getHistory(opts) {
-        var history = self.runner.taskHistory;
-        var i;
-
-        for (i = history.length; i--; ) {
-            var entry = history[i];
-            if (opts.status && opts.status !== entry.status) {
-                continue;
-            }
-            var started_at = new Date(entry.started_at);
-            var finished_at = entry.finished_at
-                ? new Date(entry.finished_at)
-                : new Date();
-            entry.elapsed_seconds = (finished_at - started_at) / 1000;
-        }
-
-        return history;
-    }
-
-    server.get('/history', function (req, res, next) {
-        var history = self.runner.taskHistory;
-        var i;
-
-        for (i = history.length; i--; ) {
-            var entry = history[i];
-            if (entry.status !== 'active') {
-                continue;
-            }
-            var started_at = new Date(entry.started_at);
-            var finished_at = entry.finished_at
-                ? new Date(entry.finished_at)
-                : new Date();
-            entry.elapsed_seconds = (finished_at - started_at) / 1000;
-        }
-
-        res.send(200, history);
-        next();
-    });
-
     self.setupImageRoutes();
 
     var port = process.env.PORT ? process.env.PORT : 5309;


### PR DESCRIPTION
The GET /tasks and GET /history routes are unused and don't fit
the usage pattern of this agent.