### PR TITLE
AGENT-918: Add documentation and tests for cn-agent HTTP routes.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -149,6 +149,183 @@ Finally the `finish` event message is sent.
         <result parameters>
     }
 
+# Task Agent HTTP API
+
+## Error Response Object
+
+    {
+        "code": "InvalidArgument",
+        "message": "Missing key 'task'"
+    }
+
+## CreateTask (POST /tasks)
+Returns an object of type task. The task object returned is specified in the
+query parameter `task`.
+
+POST /tasks?task=[task kind]
+
+### CreateTask Responses
+
+| Code | Description                     | Response                      |
+| ---- | ------------------------------- | ----------------------------- |
+| 200  | OK                              | Object of the given task type |
+| 404  | RESOURCE NOT FOUND              | Error object                  |
+| 409  | CONFLICT / InvalidArgumentError | Error object                  |
+| 500  | SERVER ERROR                    | Error object                  |
+
+### Inputs
+
+| Param  | Type   | Required? | Description                            |
+| ------ | ------ | --------- | -------------------------------------- |
+| task   | string | required  | The kind of task to create             |
+| params | Object | required  | Object containing parameters to update |
+
+### CreateTask examples
+Add metadata to a machine
+
+    POST /tasks?task=machine_update
+    {
+        "params": {
+          "server_uuid": "564df87e-d162-19e3-c46f-ab54c29b9e72",
+          "uuid": "540fe764-0ccb-4208-ad41-522ed88767af",
+          "set_internal_metadata": {
+            "propertyOne": "false",
+            "propertyTwo": "true"
+          }
+        }
+    }
+
+Remove a NIC from a machine
+
+    POST /tasks?task=machine_update
+    {
+        "params": {
+          "server_uuid": "564df87e-d162-19e3-c46f-ab54c29b9e72",
+          "uuid": "540fe764-0ccb-4208-ad41-522ed88767af",
+          "remove_nics": [
+            "90:b8:d0:68:b9:1d"
+          ],
+          "task": "remove_nics",
+          "vm_uuid": "540fe764-0ccb-4208-ad41-522ed88767af",
+          "owner_uuid": "930896af-bf8c-48d4-885c-6573a94b1853",
+          "last_modified": "2015-08-18T05:28:38.000Z",
+          "wantResolvers": true,
+          "x-request-id": "acc59cf0-456a-11e5-8097-a3cd9f6470d6",
+          "creator_uuid": "930896af-bf8c-48d4-885c-6573a94b1853",
+          "origin": "adminui",
+          "oldMacs": [
+            "c2:ae:d4:6d:19:06",
+            "90:b8:d0:68:b9:1d"
+          ],
+          "jobid": "6e9fd765-c8e7-41d6-8000-3d6354bb47d5",
+          "resolvers": [
+            "10.99.99.11"
+          ],
+          "remove_ips": [
+            "10.88.88.6"
+          ]
+        }
+    }
+
+Add a NIC to a machine
+
+    POST /tasks?task=machine_update
+    {
+        "params": {
+          "server_uuid": "564df87e-d162-19e3-c46f-ab54c29b9e72",
+          "uuid": "540fe764-0ccb-4208-ad41-522ed88767af",
+          "networks": [
+            {
+              "ipv4_uuid": "54f38ed1-bf03-4c6c-8b56-6182145ffc80",
+              "ipv4_count": 1,
+              "uuid": "54f38ed1-bf03-4c6c-8b56-6182145ffc80"
+            }
+          ],
+          "task": "add_nics",
+          "vm_uuid": "540fe764-0ccb-4208-ad41-522ed88767af",
+          "owner_uuid": "930896af-bf8c-48d4-885c-6573a94b1853",
+          "last_modified": "2015-08-18T05:23:58.000Z",
+          "oldResolvers": [
+            "10.99.99.11",
+            "8.8.8.8",
+            "8.8.4.4"
+          ],
+          "wantResolvers": true,
+          "x-request-id": "8a82d1e0-4569-11e5-8097-a3cd9f6470d6",
+          "creator_uuid": "930896af-bf8c-48d4-885c-6573a94b1853",
+          "origin": "adminui",
+          "jobid": "0360f3f7-b825-439b-ab76-ce00c285e56e",
+          "add_nics": [
+            {
+              "belongs_to_type": "zone",
+              "belongs_to_uuid": "540fe764-0ccb-4208-ad41-522ed88767af",
+              "mac": "90:b8:d0:68:b9:1d",
+              "owner_uuid": "930896af-bf8c-48d4-885c-6573a94b1853",
+              "primary": false,
+              "state": "provisioning",
+              "ip": "10.88.88.6",
+              "gateway": "10.88.88.2",
+              "mtu": 1500,
+              "netmask": "255.255.255.0",
+              "nic_tag": "external",
+              "resolvers": [
+                "8.8.8.8",
+                "8.8.4.4"
+              ],
+              "vlan_id": 0,
+              "network_uuid": "54f38ed1-bf03-4c6c-8b56-6182145ffc80"
+            }
+          ],
+          "resolvers": [
+            "10.99.99.11",
+            "8.8.8.8",
+            "8.8.4.4"
+          ]
+        }
+    }
+
+List ZFS datasets on a machine
+
+    POST /tasks?task=zfs_list_datasets
+    {
+      "params": {
+      }
+    }
+
+## GetImage (GET /images/:uuid)
+
+Returns an image manifest object.
+GET /images/[image uuid]
+
+### GetImage Responses
+
+| Code | Description                     | Response                      |
+| ---- | ------------------------------- | ----------------------------- |
+| 200  | OK                              | Image manifest object         |
+| 404  | RESOURCE NOT FOUND              | Error object                  |
+| 500  | SERVER ERROR                    | Error object                  |
+
+## GetImage example
+
+    GET /images/fd2cc906-8938-11e3-beab-4359c665ac99
+
+## GetImageFile (GET /images/:uuid/file)
+
+Returns an image file.
+GET /images/[image uuid]/file
+
+### GetImageFile Responses
+
+| Code | Description                     | Response                      |
+| ---- | ------------------------------- | ----------------------------- |
+| 200  | OK                              | Image manifest object         |
+| 404  | RESOURCE NOT FOUND              | Error object                  |
+| 500  | SERVER ERROR                    | Error object                  |
+
+## GetImageFile example
+
+    GET /images/fd2cc906-8938-11e3-beab-4359c665ac99/file
+
 # Tasks
 
 # Machine Tasks
@@ -206,4 +383,3 @@ TODO
 # Operator Guide
 
 TODO: examples using taskadm, logs location (separated out task logs), etc
-

--- a/test/http-image.test.js
+++ b/test/http-image.test.js
@@ -1,0 +1,126 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var testCase = require('nodeunit').testCase;
+var restify = require('restify');
+var Logger = require('bunyan');
+var smartdcconfig = require('../lib/smartdc-config');
+
+var PROVISIONER_PORT = 5309;
+var imageUuid = 'fd2cc906-8938-11e3-beab-4359c665ac99';
+var nonImageUuid = 'hijklmno-pqrs-tuvw-xyza-bcdefghijklm';
+var client;
+
+function firstAdminIp(sysinfo) {
+    var interfaces;
+
+    interfaces = sysinfo['Network Interfaces'];
+
+    for (var iface in interfaces) {
+        if (!interfaces.hasOwnProperty(iface)) {
+            continue;
+        }
+
+        var nic = interfaces[iface]['NIC Names'];
+        var isAdmin = nic.indexOf('admin') !== -1;
+        if (isAdmin) {
+            var ip = interfaces[iface].ip4addr;
+            return ip;
+        }
+    }
+
+    throw new Error('No NICs with name "admin" detected.');
+}
+
+function setup(cb) {
+    smartdcconfig.sysinfo(function (err, sysinfo) {
+        var adminip;
+
+        if (err) {
+            cb(err);
+            return;
+        }
+
+        adminip = firstAdminIp(sysinfo);
+        if (!adminip) {
+            throw new Error('failed to find admin IP');
+        }
+
+        client = restify.createJsonClient({
+            agent: false,
+            url: 'http://' + adminip + ':' + PROVISIONER_PORT
+        });
+
+        cb();
+    });
+}
+
+function teardown(cb) {
+    cb();
+}
+
+function testGetImageManifestHttp(test) {
+    test.expect(3);
+    var path = '/images/' + imageUuid;
+    client.get(path, function (err, req, res, tasks) {
+        test.ifError(err);
+        if (!err) {
+            test.ok(res, 'got a response');
+            test.equal(res.statusCode, 200, 'GET /images/:uuid returned 200');
+        }
+        test.done();
+    });
+}
+
+function testGetNonImageManifestHttp(test) {
+    test.expect(2);
+    var path = '/images/' + nonImageUuid;
+    client.get(path, function (err, req, res, tasks) {
+        if (err) {
+            test.ok(res, 'got a response');
+            test.equal(res.statusCode, 404, 'GET /images/:uuid returned 404');
+        }
+        test.done();
+    });
+}
+
+function testGetImageFileHttp(test) {
+    test.expect(3);
+    var path = '/images/' + imageUuid + '/file';
+    client.get(path, function (err, req, res, tasks) {
+        test.ifError(err);
+        if (!err) {
+            test.ok(res, 'got a response');
+            test.equal(res.statusCode, 200, 'GET /images/:uuid/file returned 200');
+        }
+        test.done();
+    });
+}
+
+function testGetNonImageFileHttp(test) {
+    test.expect(2);
+    var path = '/images/' + nonImageUuid + '/file';
+    client.get(path, function (err, req, res, tasks) {
+        if (err) {
+            test.ok(res, 'got a response');
+            test.equal(res.statusCode, 404, 'GET /images/:uuid/file returned 404');
+        }
+        test.done();
+    });
+}
+
+module.exports = {
+    setUp: setup,
+    tearDown: teardown,
+    'retrieve an image manifest via http': testGetImageManifestHttp,
+    'retrieve a non-image manifest via http': testGetNonImageManifestHttp,
+    'retrieve an image file via http': testGetImageFileHttp,
+    'retrieve a non-image file via http': testGetNonImageFileHttp
+};

--- a/test/http-task.test.js
+++ b/test/http-task.test.js
@@ -55,6 +55,7 @@ function setup(cb) {
             agent: false,
             url: 'http://' + adminip + ':' + PROVISIONER_PORT
         });
+
         cb();
     });
 }
@@ -65,14 +66,31 @@ function teardown(cb) {
 
 function testExecuteTaskHttp(test) {
     test.expect(3);
-    var payload = {
-        task: 'nop',
+    var bodyObj = {
         params: {}
     };
-    client.post('/tasks', payload, function (err, req, res, tasks) {
+
+    client.post('/tasks?task=zfs_list_datasets', bodyObj, function (err, req, res, tasks) {
         test.ifError(err);
-        test.ok(res, 'got a response');
-        test.equal(res.statusCode, 200, 'GET /tasks returned success');
+        if (!err) {
+            test.ok(res, 'got a response');
+            test.equal(res.statusCode, 200, 'POST /tasks returned 200');
+        }
+        test.done();
+    });
+}
+
+function testExecuteNonTaskHttp(test) {
+    test.expect(2);
+    var bodyObj = {
+        params: {}
+    };
+
+    client.post('/tasks?task=this_is_not_a_task', bodyObj, function (err, req, res, tasks) {
+        if (err) {
+            test.ok(res, 'got a response');
+            test.equal(res.statusCode, 404, 'POST /tasks returned 404');
+        }
         test.done();
     });
 }
@@ -80,5 +98,6 @@ function testExecuteTaskHttp(test) {
 module.exports = {
     setUp: setup,
     tearDown: teardown,
-    'execute a task via http': testExecuteTaskHttp
+    'execute a task via http': testExecuteTaskHttp,
+    'execute a non-task via http': testExecuteNonTaskHttp
 };


### PR DESCRIPTION
Test files were changed to match the pattern the Makefile expects.

The documentation does not attempt to make an exhaustive set of example objects, but does give enough for end users to learn from.