### PR TITLE
AGENT-1001 Tags not being set on instances on ancient platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tracker": "git+ssh://git@github.com:joyent/node-tracker.git#3a139906c9eb8d8684ac54cf54cd010315856042",
     "vasync": "^1.6.3",
     "verror": "1.6.0",
-    "vmadm": "git+ssh://git@github.com:joyent/node-vmadm.git#cd73ad50c8b432cf361beb37af80bf91af93f5d6",
+    "vmadm": "git+ssh://git@github.com:joyent/node-vmadm.git#3cf878481d24c1bc1e74e85a95004a3dde6329f1",
     "zfs": "git+ssh://git@github.com:joyent/node-zfs.git#657a90d9424c45066e3e0919dfe9b34f5636e0e9"
   },
   "sdcDependencies": {


### PR DESCRIPTION
node-vmadm (from December) was changed to use vmadm get instead of vmadm lookup to load VMs. This works even on the ancient platforms in JPC.