### PR TITLE
TRITON-1809 Snapshots are lost during migration of SmartOS containers

### DIFF
--- a/lib/backends/smartos/tasks/machine_migrate.js
+++ b/lib/backends/smartos/tasks/machine_migrate.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var child_process = require('child_process');
@@ -19,7 +19,7 @@ var VError = require('verror').VError;
 
 var Task = require('../../../task_agent/task');
 
-var SNAPSHOT_NAME_PREFIX = 'vm-migrate-estimate';
+var SNAPSHOT_NAME_PREFIX = 'vm-migration-';
 
 var gExecFileDefaults = {
     // The default maxBuffer for child_process.execFile is 200Kb, we use a much
@@ -626,10 +626,15 @@ function removeSyncSnapshots(callback) {
                 next(new zfsError('zfs list failure', err, stderr));
                 return;
             }
+            // The 'name' variable will look like this:
+            //    zones/36cf8056-47a0-63e4-80e2-a1b28cf396ab@vm-migration-3
             ctx.snapshots = stdout.trim().split('\n').filter(
                     function _filterEmptySnapshotNames(name) {
-                // When there are no snapshots - we end up with an empty string.
-                return name;
+                var idx = name.indexOf('@');
+                if (idx === -1) {
+                    return false;
+                }
+                return name.substr(idx+1).startsWith(SNAPSHOT_NAME_PREFIX);
             });
             next();
         });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cn-agent",
   "description": "Triton Compute Node Agent",
-  "version": "2.12.7",
+  "version": "2.12.8",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This ensures we don't delete other (non-migration) snapshots when finishing the migration.

Note that tests are in a separate sdc-vmapi change.