### PR TITLE
TRITON-2077 docker cp should support parallel file copying

### DIFF
--- a/lib/backends/smartos/lib/docker-stdio.js
+++ b/lib/backends/smartos/lib/docker-stdio.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -18,7 +18,6 @@
 
 
 var assert = require('assert-plus');
-var async = require('async');
 var bunyan = require('bunyan');
 var child_process = require('child_process');
 var execFile = child_process.execFile;
@@ -50,6 +49,25 @@ var CTRL_Q = '\u0011';
  * stopped containers residing on servers older than that.
  */
 var SAFE_ZLOGIN_PI = '20160922T144810Z';
+
+// Escape zlogin safe mode shell command line argument.
+function shQuote(s) {
+    // We need to escape space (for gtar to work).
+    var result = s.replace(/\s/g, '\\$&');
+    // Escape any single quote characters by using '"'"'.
+    result = result.replace('\'', '\'"\'"\'');
+    // Wrap the string in single quotes.
+    return '\'' + result + '\'';
+}
+
+// Wrap each argument in single quotes, ensuring to escape any single quotes
+// inside each argument.
+function bashCmdToString(cmd) {
+    cmd = cmd.map(function (s) {
+        return '\'' + s.replace('\'', '\'"\'"\'') + '\'';
+    });
+    return cmd.join(' ');
+}
 
 /**
  * Sets up a mechanism for starting a server to relay the contents of a file.
@@ -251,30 +269,29 @@ function createDockerFileReadStreamServer(opts, callback) {
         uuid: opts.uuid
     };
 
-    var tryUnmountLocal = once(tryUnmount);
-
     var closeTcpServer = once(function _closeTcpServer() {
         if (tcpServer) {
             tcpServer.close();
         }
     });
 
-    async.waterfall([
+    vasync.pipeline({funcs: [
         /**
          * Capture zone state, as this will dictate which method we use to do
          * the copying.
          */
-        function (next) {
+        function _loadVm(_, next) {
             vmadm.load(loadOpts, function (err, vm) {
                 if (err) {
                     next(err);
                     return;
                 }
                 zoneState = vm.zone_state;
+                log.debug({zoneState: zoneState, vmState: vm.state}, 'loadVm');
                 next();
             });
         },
-        function _checkVersion(next) {
+        function _checkVersion(_, next) {
             if (zoneState !== 'running' &&
                 opts.sysinfo['Live Image'] < SAFE_ZLOGIN_PI)
             {
@@ -287,7 +304,7 @@ function createDockerFileReadStreamServer(opts, callback) {
         /**
          * Create TCP Server which will output the archive stream
          */
-        function (next) {
+        function _createTcpServer(_, next) {
             tcpServer = net.createServer();
 
             var onceNext = once(next);
@@ -298,6 +315,13 @@ function createDockerFileReadStreamServer(opts, callback) {
                      timeoutSeconds + ' seconds without connection');
                 closeTcpServer();
             }, timeoutSeconds * 1000);
+
+            tcpServer.on('connection', function _onConnection() {
+                clearTimeout(serverTimeout);
+                // We only use one connection, so once we get that connection
+                // the tcp server can be shutdown.
+                closeTcpServer();
+            });
 
             if (zoneState === 'running') {
                 tcpServer.on('connection', onReadConnectionZoneRunning);
@@ -314,7 +338,7 @@ function createDockerFileReadStreamServer(opts, callback) {
                 onceNext();
             });
         }
-    ], function (err) {
+    ]}, function _piplineReadStreamCb(err) {
         if (err) {
             clearTimeout(serverTimeout);
             closeTcpServer();
@@ -327,20 +351,15 @@ function createDockerFileReadStreamServer(opts, callback) {
 
 
     function onReadConnectionZoneRunning(socket) {
-        clearTimeout(serverTimeout);
-
-        socket.on('close', function () {
-            closeTcpServer();
-        });
-
-        var tar = ['/native/usr/bin/gtar', 'cf', '-'];
-
-        tar.push('-C', path.dirname(norm), path.basename(norm));
-
         var zloginTarCmd = '/usr/sbin/zlogin';
         var zloginTarArgs = ['-Q', uuid];
 
-        Array.prototype.push.apply(zloginTarArgs, tar);
+        var bashCmd = ['/native/usr/bin/bash', '-c'];
+        Array.prototype.push.apply(zloginTarArgs, bashCmd);
+
+        var tar = ['/native/usr/bin/gtar', 'cf', '-', '-C', path.dirname(norm),
+            path.basename(norm)];
+        zloginTarArgs.push(bashCmdToString(tar));
 
         log.info({ zloginTarArgs: zloginTarArgs },
                  'createDockerFileReadStreamServer ' +
@@ -355,7 +374,6 @@ function createDockerFileReadStreamServer(opts, callback) {
         });
 
         streamProc.on('exit', function (err) {
-            closeTcpServer();
             if (err) {
                 log.error(err);
             }
@@ -365,7 +383,6 @@ function createDockerFileReadStreamServer(opts, callback) {
             if (err) {
                 log.error(err);
             }
-            closeTcpServer();
         });
 
         streamProc.stdout.setTimeout(DATA_TIMEOUT_MS);
@@ -378,20 +395,27 @@ function createDockerFileReadStreamServer(opts, callback) {
     }
 
     function onReadConnectionZoneNotRunning(socket) {
-        clearTimeout(serverTimeout);
+        var zoneMounted = false;
 
-        socket.on('close', function () {
-            closeTcpServer();
-        });
-
-        var tar = ['/usr/bin/gtar', 'cf', '-'];
-
-        tar.push('-C', '/a' + path.dirname(norm), path.basename(norm));
+        function tryUnmountLocal(unmountOpts, cb) {
+            if (!zoneMounted) {
+                if (cb) {
+                    cb();
+                }
+                return;
+            }
+            zoneMounted = false;
+            tryUnmount(unmountOpts, cb);
+        }
 
         var zloginTarCmd = '/usr/sbin/zlogin';
         var zloginTarArgs = ['-S', '-Q', uuid];
 
-        Array.prototype.push.apply(zloginTarArgs, tar);
+        var tar = ['/usr/bin/gtar', 'cf', '-', '-C',
+            shQuote(path.join('/a', path.dirname(norm))),
+            shQuote(path.basename(norm))];
+
+        zloginTarArgs = zloginTarArgs.concat(tar);
 
         log.info({ zloginTarArgs: zloginTarArgs },
                  'createDockerFileReadStreamServer ' +
@@ -406,6 +430,7 @@ function createDockerFileReadStreamServer(opts, callback) {
                         next(err);
                         return;
                     }
+                    zoneMounted = true;
                     next();
                 });
             },
@@ -420,7 +445,6 @@ function createDockerFileReadStreamServer(opts, callback) {
                         log.error(err);
                         next(err);
                     }
-                    closeTcpServer();
                 });
 
                 streamProc.stderr.on('data',
@@ -449,19 +473,28 @@ function createDockerFileReadStreamServer(opts, callback) {
                     log.error('onConnectionZoneRunning(read): ' +
                             'data timeout; terminating archive process');
                     streamProc.kill('SIGKILL');
-                }
-);
-                streamProc.stdout.pipe(socket);
+                });
+
+                // Pipe the file tar stream, but don't end the socket, as we
+                // want to properly unmount the zone before we end - that way
+                // any other calls to docker copy will wait until the zone is
+                // properly unmounted before performing a new copy.
+                streamProc.stdout.pipe(socket, {end: false});
 
                 streamProc.stdout.on('end', function _onReadEnd() {
-                    next();
+                    tryUnmountLocal({ uuid: uuid, log: log },
+                            function _unmountCb(err) {
+                        log.info('zone unmounted - closing the socket now');
+                        socket.end();
+                        next(err);
+                    });
                 });
             }
         ], function (err) {
             if (err) {
                 log.error(err);
+                socket.destroy();
             }
-            closeTcpServer();
             tryUnmountLocal({ uuid: uuid, log: log });
         });
     }
@@ -533,30 +566,30 @@ function createDockerFileWriteStreamServer(opts, callback) {
         uuid: opts.uuid
     };
 
-    var tryUnmountLocal = once(tryUnmount);
-
     var closeTcpServer = once(function _closeTcpServer() {
         if (tcpServer) {
             tcpServer.close();
         }
     });
 
-    async.waterfall([
+    vasync.pipeline({ funcs: [
         /**
          * Capture zone state, as this will dictate which method we use to do
          * the copying.
          */
-        function (next) {
+        function (_, next) {
             vmadm.load(loadOpts, function (err, vm) {
                 if (err) {
                     next(err);
                     return;
                 }
                 zoneState = vm.zone_state;
+                log.info({zoneState: zoneState, vmState: vm.state},
+                    'vmadm.load');
                 next();
             });
         },
-        function _checkVersion(next) {
+        function _checkVersion(_, next) {
             if (zoneState !== 'running' &&
                 opts.sysinfo['Live Image'] < SAFE_ZLOGIN_PI)
             {
@@ -569,8 +602,8 @@ function createDockerFileWriteStreamServer(opts, callback) {
         /**
          * Create TCP Server which will receive the archive stream
          */
-        function (next) {
-            tcpServer = net.createServer();
+        function (_, next) {
+            tcpServer = net.createServer({allowHalfOpen: true});
 
             var onceNext = once(next);
 
@@ -596,7 +629,7 @@ function createDockerFileWriteStreamServer(opts, callback) {
                 onceNext();
             });
         }
-    ], function (err) {
+    ]}, function (err) {
         if (err) {
             clearTimeout(serverTimeout);
             closeTcpServer();
@@ -613,12 +646,17 @@ function createDockerFileWriteStreamServer(opts, callback) {
         var overwrite = opts.no_overwrite_dir ?
             '--no-overwrite-dir' : '--overwrite';
 
-        var tar = ['/native/usr/bin/gtar', 'xf', '-', overwrite, '-C', norm];
-
         var zloginTarCmd = '/usr/sbin/zlogin';
         var zloginTarArgs = ['-Q', uuid];
 
-        Array.prototype.push.apply(zloginTarArgs, tar);
+        var bashCmd = ['/native/usr/bin/bash', '-c'];
+        Array.prototype.push.apply(zloginTarArgs, bashCmd);
+
+        var tar = ['/native/usr/bin/gtar', 'xf', '-', overwrite, '-C', norm];
+        zloginTarArgs.push(bashCmdToString(tar));
+
+        log.info({ zloginTarArgs: zloginTarArgs },
+            'onWriteConnectionZoneRunning zloginTarArgs');
 
         var streamProc =
             spawn(zloginTarCmd, zloginTarArgs, { encoding: 'binary' });
@@ -631,6 +669,7 @@ function createDockerFileWriteStreamServer(opts, callback) {
             if (err) {
                 log.error(err);
             }
+            socket.end();
             closeTcpServer();
         });
 
@@ -638,6 +677,7 @@ function createDockerFileWriteStreamServer(opts, callback) {
             if (err) {
                 log.error(err);
             }
+            socket.end();
             closeTcpServer();
         });
 
@@ -651,28 +691,45 @@ function createDockerFileWriteStreamServer(opts, callback) {
     function onWriteConnectionZoneNotRunning(socket) {
         clearTimeout(serverTimeout);
 
+        var zoneMounted = false;
         var overwrite = opts.no_overwrite_dir ?
             '--no-overwrite-dir' : '--overwrite';
-
-        var tar = ['/usr/bin/gtar', 'xf', '-', overwrite, '-C', '/a' + norm];
 
         var zloginTarCmd = '/usr/sbin/zlogin';
         var zloginTarArgs = ['-S', '-Q', uuid];
 
-        Array.prototype.push.apply(zloginTarArgs, tar);
+        var tar = ['/usr/bin/gtar', 'xf', '-', overwrite, '-C',
+            shQuote(path.join('/a', norm))];
+        zloginTarArgs = zloginTarArgs.concat(tar);
 
-        vasync.waterfall([
-            function _doWriteZoneadmMount(next) {
+        log.info({ zloginTarArgs: zloginTarArgs },
+            'onWriteConnectionZoneNotRunning zloginTarArgs');
+
+        function tryUnmountLocal(unmountOpts, cb) {
+            if (!zoneMounted) {
+                if (cb) {
+                    cb();
+                }
+                return;
+            }
+            zoneMounted = false;
+            tryUnmount(unmountOpts, cb);
+        }
+
+        vasync.pipeline({ funcs: [
+            function _doWriteZoneadmMount(_, next) {
                 common.zoneadm(uuid, ['mount'], { log: log },
-                function _onWriteStreamZoneadmMount(err) {
+                        function _onWriteStreamZoneadmMount(err) {
                     if (err) {
-                        log.error({ err: err }, 'error zoneadm mounting');
                         next(err);
+                        return;
                     }
+                    zoneMounted = true;
+                    log.info('zone mounted');
                     next();
                 });
             },
-            function _doWriteStream(next) {
+            function _doWriteStream(_, next) {
                 next = once(next);
 
                 var streamProc =
@@ -701,30 +758,34 @@ function createDockerFileWriteStreamServer(opts, callback) {
                             util.format('docker copy tar (write) process' +
                                 ' exited with a non-zero value (%d)', code)));
                         return;
+                    } else {
+                        log.info('zlogin gtar process exited successfully');
                     }
                     next();
                 });
 
                 socket.pipe(streamProc.stdin);
 
-                socket.on('close', function _onCloseEnd(err) {
-                    if (err) {
-                        log.error(err);
-                        next(err);
-                    }
-                });
-
-                socket.on('end', function _onWriteEnd() {
+                socket.on('error', function _onSocketError(err) {
+                    log.error('socket error: %s', err);
                     next();
                 });
-
             }
-        ], function (err) {
+        ]}, function (err) {
             if (err) {
                 log.error(err);
             }
             closeTcpServer();
-            tryUnmountLocal({ uuid: uuid, log: log });
+            tryUnmountLocal({ uuid: uuid, log: log },
+                    function _unmountCb(unmountErr) {
+                if (unmountErr) {
+                    log.error({uuid: uuid}, 'Error unmounting zone: %s',
+                        unmountErr);
+                } else {
+                    log.info({uuid: uuid}, 'zone unmounted');
+                }
+                socket.end();
+            });
         });
     }
 }
@@ -749,6 +810,9 @@ function getDockerContainerPathStat(opts, callback) {
 
     var error;
     var containerPathStat;
+
+    opts.log.info({abspath: abspath, path: opts.path, norm: norm},
+        'getDockerContainerPathStat');
 
     // try to fail early if possible
     try {

--- a/lib/backends/smartos/lib/docker-stdio.js
+++ b/lib/backends/smartos/lib/docker-stdio.js
@@ -480,22 +480,21 @@ function createDockerFileReadStreamServer(opts, callback) {
                 // any other calls to docker copy will wait until the zone is
                 // properly unmounted before performing a new copy.
                 streamProc.stdout.pipe(socket, {end: false});
-
-                streamProc.stdout.on('end', function _onReadEnd() {
-                    tryUnmountLocal({ uuid: uuid, log: log },
-                            function _unmountCb(err) {
-                        log.info('zone unmounted - closing the socket now');
-                        socket.end();
-                        next(err);
-                    });
-                });
             }
         ], function (err) {
-            if (err) {
-                log.error(err);
-                socket.destroy();
-            }
-            tryUnmountLocal({ uuid: uuid, log: log });
+            tryUnmountLocal({ uuid: uuid, log: log },
+                    function _unmountCb(unmountErr) {
+                if (unmountErr) {
+                    log.error('Unmount error: %s', unmountErr);
+                }
+                if (err) {
+                    log.info('zone unmounted - destroying the socket now');
+                    socket.destroy();
+                } else {
+                    log.info('zone unmounted - closing the socket now');
+                    socket.end();
+                }
+            });
         });
     }
 }
@@ -721,6 +720,7 @@ function createDockerFileWriteStreamServer(opts, callback) {
                 common.zoneadm(uuid, ['mount'], { log: log },
                         function _onWriteStreamZoneadmMount(err) {
                     if (err) {
+                        log.error({ err: err }, 'error zoneadm mounting');
                         next(err);
                         return;
                     }
@@ -772,9 +772,6 @@ function createDockerFileWriteStreamServer(opts, callback) {
                 });
             }
         ]}, function (err) {
-            if (err) {
-                log.error(err);
-            }
             closeTcpServer();
             tryUnmountLocal({ uuid: uuid, log: log },
                     function _unmountCb(unmountErr) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cn-agent",
   "description": "Triton Compute Node Agent",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The crux of this is that for a stopped zone, cn-agent first mounts the zone and runs the docker copy operation - but it must wait until the zone has fully unmounted before finalizing the docker copy socket/call, otherwise a second copy operation can try and use the zone before the first operation has fully unmounted the zone.