### PR TITLE
TRITON-2180 sdc-migrate crash when sync fails from an out of space error

### DIFF
--- a/lib/backends/smartos/bin/machine-migrate-receive.js
+++ b/lib/backends/smartos/bin/machine-migrate-receive.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -238,6 +238,11 @@ function zfsSyncReceive(opts, event, socket) {
     zfsReceive.stderr.on('data', function (buf) {
         log.info('zfsSyncReceive:: zfs receive stderr: ' + String(buf));
         storeLimitedOutput('stderr', buf);
+    });
+
+    // Must catch EPIPE errors here to avoid crashing the process.
+    zfsReceive.stdin.on('error', function _handleZfsStdinError(err) {
+        log.info('zfsSyncReceive:: zfs stdin err: %s', err);
     });
 
     // All future socket data will be piped into zfs receive.

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -524,7 +524,11 @@ function _syncHandlerConnectToReceiver(ctx, callback) {
             if (event.type === 'error') {
                 log.error({event: event},
                     'received "error" event from target cn-agent process');
-                ctx.errorCallbackHandler(new Error(event.message), event);
+                var errMsg = event.message;
+                if (event.stderr) {
+                    errMsg += ' (' + event.stderr.trim() + ')';
+                }
+                ctx.errorCallbackHandler(new Error(errMsg), event);
                 return;
             }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cn-agent",
   "description": "Triton Compute Node Agent",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
So there are two tweaks here:
1) catch the zfsReceive.stdin error (to avoid EPIPE crash)
2) improve the error message by add stderr (when available)