### PR TITLE
Support migration from unencrypted CN to encrypted CN (make check)

### DIFF
--- a/lib/backends/smartos/bin/machine-migrate-receive.js
+++ b/lib/backends/smartos/bin/machine-migrate-receive.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 /*
@@ -132,9 +132,12 @@ function zfsSyncReceive(opts, event, socket) {
         '-s', // If receive is interrupted, save the partially received state.
         '-F', // Rollback to the most recent snapshot before running receive.
               // Brings in any new snapshot names from the source.
-        // Omit the "encryption" property to allow migrating from an unencrypted CN to an encrypted CN
+        // Omit the "encryption" property to allow migrating from an
+        // unencrypted CN to an encrypted CN
         // This avoids the following error on the receiving end:
-        //      "zfs receive exited with code: 1 (cannot receive new filesystem stream: parent 'zones' must not be encrypted to receive unenecrypted property)"
+        // "zfs receive exited with code: 1 (cannot receive new filesystem
+        // stream: parent 'zones' must not be encrypted to receive unenecrypted
+        // property)"
         '-x', 'encryption',
         event.zfsFilesystem
     ];


### PR DESCRIPTION
Subject says it all.  Missed copyright and <80 chars on a line.
