### PR TITLE
Fix migration from encrypted compute nodes (issue #92)

### DIFF
--- a/lib/backends/smartos/bin/machine-migrate-receive.js
+++ b/lib/backends/smartos/bin/machine-migrate-receive.js
@@ -145,34 +145,11 @@ function zfsSyncReceive(opts, event, socket) {
     // Add properties from the source dataset
     if (event.properties && typeof event.properties === 'object') {
         var propKeys = Object.keys(event.properties);
-        var appliedProps = [];
-
         propKeys.forEach(function _addProperty(prop) {
             var value = event.properties[prop];
-
-            // Validate property name (alphanumeric, underscore, colon only)
-            if (!/^[a-z][a-z0-9_:]*$/i.test(prop)) {
-                log.warn({property: prop},
-                    'Skipping property with invalid name');
-                return;
-            }
-
-            // Validate value is string or number
-            if (typeof value !== 'string' && typeof value !== 'number') {
-                log.warn({property: prop, value: value, valueType: typeof value},
-                    'Skipping property with non-string/number value');
-                return;
-            }
-
             args.push('-o');
             args.push(prop + '=' + value);
-            appliedProps.push(prop);
         });
-
-        if (appliedProps.length > 0) {
-            log.info({properties: appliedProps, count: appliedProps.length},
-                'Applying properties during zfs receive');
-        }
     }
 
     args.push(event.zfsFilesystem);

--- a/lib/backends/smartos/bin/machine-migrate-receive.js
+++ b/lib/backends/smartos/bin/machine-migrate-receive.js
@@ -125,6 +125,7 @@ function zfsSyncReceive(opts, event, socket) {
     assert.string(event.zfsFilesystem, 'event.zfsFilesystem');
     assert.object(socket, 'socket');
 
+    var log = opts.log;
     var cmd = '/usr/sbin/zfs';
     var args = [
         'receive',
@@ -144,16 +145,38 @@ function zfsSyncReceive(opts, event, socket) {
     // Add properties from the source dataset
     if (event.properties && typeof event.properties === 'object') {
         var propKeys = Object.keys(event.properties);
+        var appliedProps = [];
+
         propKeys.forEach(function _addProperty(prop) {
             var value = event.properties[prop];
+
+            // Validate property name (alphanumeric, underscore, colon only)
+            if (!/^[a-z][a-z0-9_:]*$/i.test(prop)) {
+                log.warn({property: prop},
+                    'Skipping property with invalid name');
+                return;
+            }
+
+            // Validate value is string or number
+            if (typeof value !== 'string' && typeof value !== 'number') {
+                log.warn({property: prop, value: value, valueType: typeof value},
+                    'Skipping property with non-string/number value');
+                return;
+            }
+
             args.push('-o');
             args.push(prop + '=' + value);
+            appliedProps.push(prop);
         });
+
+        if (appliedProps.length > 0) {
+            log.info({properties: appliedProps, count: appliedProps.length},
+                'Applying properties during zfs receive');
+        }
     }
 
     args.push(event.zfsFilesystem);
 
-    var log = opts.log;
     var output = {
         stdout: null,
         stderr: null

--- a/lib/backends/smartos/bin/machine-migrate-receive.js
+++ b/lib/backends/smartos/bin/machine-migrate-receive.js
@@ -138,9 +138,21 @@ function zfsSyncReceive(opts, event, socket) {
         // "zfs receive exited with code: 1 (cannot receive new filesystem
         // stream: parent 'zones' must not be encrypted to receive unenecrypted
         // property)"
-        '-x', 'encryption',
-        event.zfsFilesystem
+        '-x', 'encryption'
     ];
+
+    // Add properties from the source dataset
+    if (event.properties && typeof event.properties === 'object') {
+        var propKeys = Object.keys(event.properties);
+        propKeys.forEach(function _addProperty(prop) {
+            var value = event.properties[prop];
+            args.push('-o');
+            args.push(prop + '=' + value);
+        });
+    }
+
+    args.push(event.zfsFilesystem);
+
     var log = opts.log;
     var output = {
         stdout: null,
@@ -148,12 +160,13 @@ function zfsSyncReceive(opts, event, socket) {
     };
     var responseEvent;
 
+    log.debug({cmd: cmd, args: args, propertyCount: event.properties ?
+        Object.keys(event.properties).length : 0}, 'zfsSyncReceive');
+
     // Disconnect the line stream reader.
     socket.unpipe(opts.commandStream);
 
     log.debug('zfsSyncReceive:: unpiped command stream');
-
-    log.debug({cmd: cmd, args: args}, 'zfsSyncReceive');
 
     var zfsReceive = child_process.spawn(cmd, args,
         {
@@ -320,6 +333,51 @@ function commandZfsDestroy(opts, event, socket) {
             eventId: event.eventId
         };
 
+        writeEvent(socket, responseEvent);
+    });
+}
+
+function commandImportImage(opts, event, socket) {
+    assert.object(opts, 'opts');
+    assert.object(opts.log, 'opts.log');
+    assert.object(event, 'event');
+    assert.string(event.imageUuid, 'event.imageUuid');
+    assert.object(socket, 'socket');
+
+    var log = opts.log;
+    var responseEvent;
+
+    log.info({imageUuid: event.imageUuid}, 'commandImportImage: importing image');
+
+    var cmd = '/usr/sbin/imgadm';
+    var args = ['import', event.imageUuid];
+
+    child_process.execFile(cmd, args, gExecFileDefaults,
+            function _execImgadmImportCb(error, stdout, stderr) {
+        if (error) {
+            // imgadm import is idempotent - if image already exists, it succeeds
+            log.error({imageUuid: event.imageUuid},
+                'imgadm import error: %s, stderr: %s', error, stderr);
+
+            responseEvent = {
+                type: 'error',
+                command: event.command,
+                eventId: event.eventId,
+                message: 'imgadm import error: ' + error,
+                stderr: String(stderr)
+            };
+            writeEvent(socket, responseEvent);
+            return;
+        }
+
+        log.info({imageUuid: event.imageUuid}, 'commandImportImage: success');
+
+        responseEvent = {
+            type: 'response',
+            command: event.command,
+            eventId: event.eventId,
+            message: 'Image imported successfully'
+        };
         writeEvent(socket, responseEvent);
     });
 }
@@ -695,6 +753,9 @@ function onSocketCommand(opts, socket, line) {
             break;
         case 'get-zfs-snapshot-names':
             commandGetZfsSnapshotNames(opts, event, socket);
+            break;
+        case 'import-image':
+            commandImportImage(opts, event, socket);
             break;
         case 'sync':
             commandSync(opts, event, socket);

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -785,6 +785,17 @@ function _syncHandlerGetZfsProperties(ctx, callback) {
     var self = this;
     var log = self.log;
 
+    // If dataset is not encrypted, we use --replicate which already includes
+    // all properties in the stream, so no need to collect them manually
+    if (!ctx.isEncrypted) {
+        ctx.properties = {};
+        log.debug({zfsFilesystem: ctx.zfsFilesystem},
+            'Dataset not encrypted, skipping manual property collection ' +
+            '(properties included via --replicate)');
+        callback();
+        return;
+    }
+
     // Properties to exclude (read-only, auto-preserved, or encryption-related)
     var EXCLUDE_PROPERTIES = [
         // Read-only/computed properties

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -1402,7 +1402,11 @@ SyncHandler.prototype.setupSync = function _syncHandleSetupSync(ctx, callback) {
         isFirstSync: ctx.isFirstSync,
         resumeSync: ctx.resumeSync,
         zfsFilesystem: self.convertTargetZfsFilesystem(ctx.zfsFilesystem),
-        properties: ctx.properties || {}
+        // Only send properties on first sync (when creating the dataset)
+        // On incremental syncs, dataset already exists with correct properties,
+        // and trying to set them again (especially mountpoint on zoned datasets)
+        // will fail
+        properties: ctx.isFirstSync ? (ctx.properties || {}) : {}
     };
 
     self.runTargetCommand(ctx.receiverSocket, command, callback);

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -840,11 +840,21 @@ function _syncHandlerGetZfsProperties(ctx, callback) {
         'receive_resume_token', 'referenced', 'refcompressratio', 'type',
         'used', 'usedbychildren', 'usedbydataset', 'usedbyrefreservation',
         'usedbysnapshots', 'userrefs', 'written',
+        // Additional read-only properties
+        'name', 'createtxg', 'filesystem_count', 'snapshot_count',
+        'mlslabel', 'redacted',
+        // Read-only after creation
+        'normalization', 'casesensitivity', 'utf8only', 'version',
         // Encryption (handled by target CN's encryption key)
         'encryption', 'encryptionroot', 'keylocation', 'keyformat',
         'keystatus', 'pbkdf2iters',
         // Auto-preserved by zfs send/recv
-        'volsize', 'volblocksize'
+        'volsize', 'volblocksize',
+        // Handled separately or should not be transferred
+        'origin',  // Handled separately via getZfsOrigin()
+        'zoned',   // Managed by ZFS based on dataset context
+        // Redaction properties
+        'redact_snaps'
     ];
 
     var cmd = '/usr/sbin/zfs';

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -418,7 +418,7 @@ SyncHandler.prototype.run = function _syncHandlerRun(callback) {
     var self = this;
     var log = self.log;
 
-    vasync.pipeline({funcs: [
+    vasync.pipeline({arg: {}, funcs: [
         function discoverAllChildDatasets(ctx, next) {
             self.discoverAllChildDatasets(next);
         },

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -351,46 +351,82 @@ function _syncHandlerDiscoverAllChildDatasets(callback) {
         'Discovering child datasets for all top-level datasets');
 
     function discoverForOneDataset(zfsFilesystem, next) {
-        var cmd = '/usr/sbin/zfs';
-        var args = [
-            'list',
-            '-H',
-            '-r',
-            '-t', 'filesystem,volume',
-            '-o', 'name',
-            zfsFilesystem
-        ];
+        // First check if this dataset is encrypted
+        var encCmd = '/usr/sbin/zfs';
+        var encArgs = ['get', '-H', '-o', 'value', 'encryption', zfsFilesystem];
 
-        child_process.execFile(cmd, args, gExecFileDefaults,
-                function _execZfsListChildCb(err, stdout, stderr) {
-            if (err) {
-                log.error({cmd: cmd, args: args},
-                    'Error listing child datasets, err: %s, stderr: %s',
-                    err, stderr);
-                next(err);
+        child_process.execFile(encCmd, encArgs, gExecFileDefaults,
+                function _execZfsGetEncryptionCb(encErr, encStdout, encStderr) {
+            if (encErr) {
+                log.error({cmd: encCmd, args: encArgs},
+                    'Error checking encryption, err: %s, stderr: %s',
+                    encErr, encStderr);
+                next(encErr);
                 return;
             }
 
-            var lines = String(stdout).trim().split('\n');
+            var encryption = String(encStdout).trim();
+            var isEncrypted = (encryption !== 'off' && encryption !== '-');
 
-            // First line is the parent dataset itself, skip it and add the rest
-            for (var i = 1; i < lines.length; i++) {
-                var childFs = lines[i].trim();
-                if (childFs && childFs !== zfsFilesystem) {
-                    // Add child dataset to the datasets object if not already present
-                    if (!self.datasets[childFs]) {
-                        self.datasets[childFs] = {
-                            zfsFilesystem: childFs,
-                            isChildDataset: true,
-                            parentDataset: zfsFilesystem
-                        };
-                        log.info({childDataset: childFs, parent: zfsFilesystem},
-                            'Discovered child dataset');
-                    }
-                }
+            log.debug({
+                zfsFilesystem: zfsFilesystem,
+                encryption: encryption,
+                isEncrypted: isEncrypted
+            }, 'Checked encryption for child discovery');
+
+            // If not encrypted, we'll use --replicate which handles children
+            // automatically, so skip child discovery
+            if (!isEncrypted) {
+                log.info({zfsFilesystem: zfsFilesystem},
+                    'Dataset not encrypted, skipping child discovery ' +
+                    '(children included via --replicate)');
+                next();
+                return;
             }
 
-            next();
+            // Dataset is encrypted, need to discover children since we can't
+            // use --replicate
+            var cmd = '/usr/sbin/zfs';
+            var args = [
+                'list',
+                '-H',
+                '-r',
+                '-t', 'filesystem,volume',
+                '-o', 'name',
+                zfsFilesystem
+            ];
+
+            child_process.execFile(cmd, args, gExecFileDefaults,
+                    function _execZfsListChildCb(err, stdout, stderr) {
+                if (err) {
+                    log.error({cmd: cmd, args: args},
+                        'Error listing child datasets, err: %s, stderr: %s',
+                        err, stderr);
+                    next(err);
+                    return;
+                }
+
+                var lines = String(stdout).trim().split('\n');
+
+                // First line is the parent dataset itself, skip it and add the rest
+                for (var i = 1; i < lines.length; i++) {
+                    var childFs = lines[i].trim();
+                    if (childFs && childFs !== zfsFilesystem) {
+                        // Add child dataset to the datasets object if not already present
+                        if (!self.datasets[childFs]) {
+                            self.datasets[childFs] = {
+                                zfsFilesystem: childFs,
+                                isChildDataset: true,
+                                parentDataset: zfsFilesystem
+                            };
+                            log.info({childDataset: childFs, parent: zfsFilesystem},
+                                'Discovered child dataset');
+                        }
+                    }
+                }
+
+                next();
+            });
         });
     }
 

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -852,7 +852,7 @@ function _syncHandlerGetZfsProperties(ctx, callback) {
         'get',
         '-H',
         '-o', 'property,value,source',
-        '-s', 'local',  // Only locally-set properties
+        '-s', 'local,received',  // Locally-set and received properties
         'all',
         ctx.zfsFilesystem
     ];

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -244,6 +244,9 @@ function _syncHandlerCollectSyncInfo(zfsFilesystemNames, callback) {
 
         vasync.pipeline({arg: dsCtx, funcs: [
             self.getSourceZfsSnapshotNames.bind(self),
+            self.checkZfsEncryption.bind(self),
+            self.getZfsProperties.bind(self),
+            self.getZfsOrigin.bind(self),
             self.connectToReceiver.bind(self),
             self.pipelineCheckSyncAborted.bind(self),
             self.getTargetZfsSnapshotNames.bind(self),
@@ -307,6 +310,7 @@ function _syncHandlerSyncDatasets(zfsFilesystemNames, callback) {
         vasync.pipeline({arg: dsCtx, funcs: [
             self.connectToReceiver.bind(self),
             self.pipelineCheckSyncAborted.bind(self),
+            self.ensureOriginImageOnTarget.bind(self),
             self.setupSync.bind(self),
             self.startSync.bind(self),
             self.waitForSyncSuccess.bind(self),
@@ -335,22 +339,100 @@ function _syncHandlerSyncDatasets(zfsFilesystemNames, callback) {
     });
 };
 
+SyncHandler.prototype.discoverAllChildDatasets =
+function _syncHandlerDiscoverAllChildDatasets(callback) {
+    var self = this;
+    var log = self.log;
+
+    // Get the initial list of top-level datasets
+    var topLevelDatasets = Object.keys(self.datasets);
+
+    log.info({topLevelDatasets: topLevelDatasets},
+        'Discovering child datasets for all top-level datasets');
+
+    function discoverForOneDataset(zfsFilesystem, next) {
+        var cmd = '/usr/sbin/zfs';
+        var args = [
+            'list',
+            '-H',
+            '-r',
+            '-t', 'filesystem,volume',
+            '-o', 'name',
+            zfsFilesystem
+        ];
+
+        child_process.execFile(cmd, args, gExecFileDefaults,
+                function _execZfsListChildCb(err, stdout, stderr) {
+            if (err) {
+                log.error({cmd: cmd, args: args},
+                    'Error listing child datasets, err: %s, stderr: %s',
+                    err, stderr);
+                next(err);
+                return;
+            }
+
+            var lines = String(stdout).trim().split('\n');
+
+            // First line is the parent dataset itself, skip it and add the rest
+            for (var i = 1; i < lines.length; i++) {
+                var childFs = lines[i].trim();
+                if (childFs && childFs !== zfsFilesystem) {
+                    // Add child dataset to the datasets object if not already present
+                    if (!self.datasets[childFs]) {
+                        self.datasets[childFs] = {
+                            zfsFilesystem: childFs,
+                            isChildDataset: true,
+                            parentDataset: zfsFilesystem
+                        };
+                        log.info({childDataset: childFs, parent: zfsFilesystem},
+                            'Discovered child dataset');
+                    }
+                }
+            }
+
+            next();
+        });
+    }
+
+    vasync.forEachPipeline({
+        inputs: topLevelDatasets,
+        func: discoverForOneDataset
+    }, function _discoverAllChildDatasetsCb(err) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        var allDatasets = Object.keys(self.datasets);
+        log.info({
+            topLevelCount: topLevelDatasets.length,
+            totalCount: allDatasets.length,
+            childCount: allDatasets.length - topLevelDatasets.length
+        }, 'Child dataset discovery complete');
+
+        callback();
+    });
+};
+
 SyncHandler.prototype.run = function _syncHandlerRun(callback) {
     var self = this;
     var log = self.log;
 
-    // For each dataset, collect and then sync to the target server.
-    var zfsFilesystemNames = Object.keys(self.datasets).sort();
-
     vasync.pipeline({funcs: [
+        function discoverAllChildDatasets(ctx, next) {
+            self.discoverAllChildDatasets(next);
+        },
         function collectSyncInfo(ctx, next) {
+            // Get the complete list of datasets (including children)
+            var zfsFilesystemNames = Object.keys(self.datasets).sort();
+            ctx.zfsFilesystemNames = zfsFilesystemNames;
             self.collectSyncInfo(zfsFilesystemNames, next);
         },
         function syncDatasets(ctx, next) {
-            self.syncDatasets(zfsFilesystemNames, next);
+            self.syncDatasets(ctx.zfsFilesystemNames, next);
         },
         function cleanupSnapshots(ctx, next) {
-            self.cleanupSnapshots(zfsFilesystemNames, next);
+            self.cleanupSnapshots(ctx.zfsFilesystemNames, next);
         }
     ]}, function _runPipelineCb(err) {
         self.shutdownReceiver(function _shutdownReceiverCb(shutdownErr) {
@@ -643,6 +725,192 @@ function _syncHandlerGetSourceZfsSnapshotNames(ctx, callback) {
 
         log.debug({sourceSnapshotNames: ctx.sourceSnapshotNames},
             'getSourceZfsSnapshotNames');
+
+        callback();
+    });
+};
+
+SyncHandler.prototype.checkZfsEncryption =
+function _syncHandlerCheckZfsEncryption(ctx, callback) {
+    assert.object(ctx, 'ctx');
+    assert.string(ctx.zfsFilesystem, 'ctx.zfsFilesystem');
+    assert.func(callback, 'callback');
+
+    var self = this;
+    var log = self.log;
+
+    var cmd = '/usr/sbin/zfs';
+    var args = [
+        'get',
+        '-H',
+        '-o',
+        'value',
+        'encryption',
+        ctx.zfsFilesystem
+    ];
+
+    log.debug({cmd: cmd, args: args}, 'checkZfsEncryption');
+
+    child_process.execFile(cmd, args, gExecFileDefaults,
+            function _execZfsGetEncryptionCb(err, stdout, stderr) {
+        if (err) {
+            log.error({cmd: cmd, args: args},
+                'Error getting encryption property, err: %s, stderr: %s',
+                err, stderr);
+            callback(err);
+            return;
+        }
+
+        // The output will be either "off" for unencrypted or an encryption
+        // algorithm name (e.g., "aes-256-ccm") for encrypted datasets.
+        var encryption = String(stdout).trim();
+        ctx.isEncrypted = (encryption !== 'off' && encryption !== '-');
+
+        log.debug({
+            zfsFilesystem: ctx.zfsFilesystem,
+            encryption: encryption,
+            isEncrypted: ctx.isEncrypted
+        }, 'checkZfsEncryption');
+
+        callback();
+    });
+};
+
+SyncHandler.prototype.getZfsProperties =
+function _syncHandlerGetZfsProperties(ctx, callback) {
+    assert.object(ctx, 'ctx');
+    assert.string(ctx.zfsFilesystem, 'ctx.zfsFilesystem');
+    assert.func(callback, 'callback');
+
+    var self = this;
+    var log = self.log;
+
+    // Properties to exclude (read-only, auto-preserved, or encryption-related)
+    var EXCLUDE_PROPERTIES = [
+        // Read-only/computed properties
+        'available', 'compressratio', 'creation', 'clones', 'defer_destroy',
+        'guid', 'logicalreferenced', 'logicalused', 'mounted', 'objsetid',
+        'receive_resume_token', 'referenced', 'refcompressratio', 'type',
+        'used', 'usedbychildren', 'usedbydataset', 'usedbyrefreservation',
+        'usedbysnapshots', 'userrefs', 'written',
+        // Encryption (handled by target CN's encryption key)
+        'encryption', 'encryptionroot', 'keylocation', 'keyformat',
+        'keystatus', 'pbkdf2iters',
+        // Auto-preserved by zfs send/recv
+        'volsize', 'volblocksize'
+    ];
+
+    var cmd = '/usr/sbin/zfs';
+    var args = [
+        'get',
+        '-H',
+        '-o', 'property,value,source',
+        '-s', 'local',  // Only locally-set properties
+        'all',
+        ctx.zfsFilesystem
+    ];
+
+    log.debug({cmd: cmd, args: args}, 'getZfsProperties');
+
+    child_process.execFile(cmd, args, gExecFileDefaults,
+            function _execZfsGetPropertiesCb(err, stdout, stderr) {
+        if (err) {
+            log.error({cmd: cmd, args: args},
+                'Error getting zfs properties, err: %s, stderr: %s',
+                err, stderr);
+            callback(err);
+            return;
+        }
+
+        var lines = String(stdout).trim().split('\n');
+        var properties = {};
+
+        lines.forEach(function _processPropertyLine(line) {
+            if (!line) {
+                return;
+            }
+
+            var parts = line.split('\t');
+            if (parts.length < 3) {
+                return;
+            }
+
+            var prop = parts[0];
+            var value = parts[1];
+            var source = parts[2];
+
+            // Skip if in exclude list
+            if (EXCLUDE_PROPERTIES.indexOf(prop) >= 0) {
+                log.trace({property: prop}, 'Skipping excluded property');
+                return;
+            }
+
+            // Include the property
+            properties[prop] = value;
+            log.trace({property: prop, value: value, source: source},
+                'Preserving property');
+        });
+
+        ctx.properties = properties;
+
+        log.debug({
+            zfsFilesystem: ctx.zfsFilesystem,
+            propertyCount: Object.keys(properties).length,
+            properties: properties
+        }, 'getZfsProperties');
+
+        callback();
+    });
+};
+
+SyncHandler.prototype.getZfsOrigin =
+function _syncHandlerGetZfsOrigin(ctx, callback) {
+    assert.object(ctx, 'ctx');
+    assert.string(ctx.zfsFilesystem, 'ctx.zfsFilesystem');
+    assert.func(callback, 'callback');
+
+    var self = this;
+    var log = self.log;
+
+    var cmd = '/usr/sbin/zfs';
+    var args = [
+        'get',
+        '-H',
+        '-o', 'value',
+        'origin',
+        ctx.zfsFilesystem
+    ];
+
+    log.debug({cmd: cmd, args: args}, 'getZfsOrigin');
+
+    child_process.execFile(cmd, args, gExecFileDefaults,
+            function _execZfsGetOriginCb(err, stdout, stderr) {
+        if (err) {
+            log.error({cmd: cmd, args: args},
+                'Error getting origin property, err: %s, stderr: %s',
+                err, stderr);
+            callback(err);
+            return;
+        }
+
+        var origin = String(stdout).trim();
+        ctx.hasOrigin = (origin !== '-');
+        ctx.origin = ctx.hasOrigin ? origin : null;
+
+        if (ctx.hasOrigin) {
+            // Extract image UUID from origin (e.g., "zones/uuid@final" -> "uuid")
+            var match = origin.match(/zones\/([0-9a-f-]{36})@/);
+            if (match) {
+                ctx.originImageUuid = match[1];
+            }
+        }
+
+        log.debug({
+            zfsFilesystem: ctx.zfsFilesystem,
+            hasOrigin: ctx.hasOrigin,
+            origin: ctx.origin,
+            originImageUuid: ctx.originImageUuid
+        }, 'getZfsOrigin');
 
         callback();
     });
@@ -942,38 +1210,58 @@ function _syncHandleGetZfsSyncArgs(ctx) {
         ];
     }
 
-    var replicateArg = '--replicate';
+    var args = ['send'];
+
+    // For encrypted datasets, we cannot use --replicate because it includes
+    // properties, and encrypted datasets cannot send properties without --raw.
+    // Since each CN has a different encryption key, we cannot use --raw either.
+    // So for encrypted datasets, we send without --replicate and handle
+    // properties separately on the receiving end.
+    var useReplicate = !ctx.isEncrypted;
 
     // Docker image datasets are created on demand for each CN, so they will
     // always be different between each CN. Thus we don't want the usual
     // --replicate argument for the base zone dataset (as that will expect
     // the origin dataset to be the same) - we want a full send instead.
     if (this.isDocker && ctx.zfsFilesystem === this.vm.zfs_filesystem) {
-        replicateArg = '--props';
+        useReplicate = false;
+    }
+
+    if (useReplicate) {
+        args.push('--replicate');
+    }
+
+    // Handle origin-based datasets (incremental from image)
+    if (ctx.hasOrigin && ctx.isFirstSync) {
+        assert.string(ctx.origin, 'ctx.origin');
+        assert.string(ctx.snapshotName, 'ctx.snapshotName');
+        assert.string(ctx.zfsFilesystem, 'ctx.zfsFilesystem');
+
+        // Send incrementally from the origin image's @final snapshot
+        args.push('-I');
+        args.push(ctx.origin);  // e.g., "zones/image-uuid@final"
+        args.push(util.format('%s@%s', ctx.zfsFilesystem, ctx.snapshotName));
+
+        return args;
     }
 
     if (ctx.isFirstSync) {
         assert.string(ctx.snapshotName, 'ctx.snapshotName');
         assert.string(ctx.zfsFilesystem, 'ctx.zfsFilesystem');
 
-        return [
-            'send',
-            replicateArg,
-            util.format('%s@%s', ctx.zfsFilesystem, ctx.snapshotName)
-        ];
+        args.push(util.format('%s@%s', ctx.zfsFilesystem, ctx.snapshotName));
+        return args;
     }
 
     assert.string(ctx.snapshotName, 'ctx.snapshotName');
     assert.string(ctx.prevSnapshotName, 'ctx.prevSnapshotName');
     assert.string(ctx.zfsFilesystem, 'ctx.zfsFilesystem');
 
-    return [
-        'send',
-        replicateArg,
-        '-I',
-        util.format('%s@%s', ctx.zfsFilesystem, ctx.prevSnapshotName),
-        util.format('%s@%s', ctx.zfsFilesystem, ctx.snapshotName)
-    ];
+    args.push('-I');
+    args.push(util.format('%s@%s', ctx.zfsFilesystem, ctx.prevSnapshotName));
+    args.push(util.format('%s@%s', ctx.zfsFilesystem, ctx.snapshotName));
+
+    return args;
 };
 
 SyncHandler.prototype.getEstimate =
@@ -1029,16 +1317,69 @@ function _syncHandleGetEstimate(ctx, callback) {
     });
 };
 
+SyncHandler.prototype.ensureOriginImageOnTarget =
+function _syncHandlerEnsureOriginImageOnTarget(ctx, callback) {
+    assert.object(ctx, 'ctx');
+    assert.object(ctx.receiverSocket, 'ctx.receiverSocket');
+    assert.func(callback, 'callback');
+
+    var self = this;
+    var log = self.log;
+
+    // Only needed if dataset has an origin
+    if (!ctx.hasOrigin || !ctx.originImageUuid) {
+        log.debug({zfsFilesystem: ctx.zfsFilesystem},
+            'No origin image, skipping image import');
+        callback();
+        return;
+    }
+
+    log.info({
+        zfsFilesystem: ctx.zfsFilesystem,
+        originImageUuid: ctx.originImageUuid
+    }, 'Ensuring origin image exists on target CN');
+
+    // Tell target CN to import the image
+    var command = {
+        command: 'import-image',
+        imageUuid: ctx.originImageUuid
+    };
+
+    this.runTargetCommand(ctx.receiverSocket, command,
+            function _importImageCb(err, event) {
+        if (err) {
+            log.error({imageUuid: ctx.originImageUuid},
+                'Failed to import origin image on target CN:', err);
+            callback(err);
+            return;
+        }
+
+        log.info({imageUuid: ctx.originImageUuid, result: event},
+            'Origin image ready on target CN');
+        callback();
+    });
+};
+
 SyncHandler.prototype.setupSync = function _syncHandleSetupSync(ctx, callback) {
-    this.log.info('setupSync');
+    assert.object(ctx, 'ctx');
+    assert.object(ctx.receiverSocket, 'ctx.receiverSocket');
+    assert.func(callback, 'callback');
+
+    var self = this;
+    var log = self.log;
+
+    log.info('setupSync');
+
     // This will start the zfs receive on the target.
     var command = {
         command: 'sync',
         isFirstSync: ctx.isFirstSync,
         resumeSync: ctx.resumeSync,
-        zfsFilesystem: this.convertTargetZfsFilesystem(ctx.zfsFilesystem)
+        zfsFilesystem: self.convertTargetZfsFilesystem(ctx.zfsFilesystem),
+        properties: ctx.properties || {}
     };
-    this.runTargetCommand(ctx.receiverSocket, command, callback);
+
+    self.runTargetCommand(ctx.receiverSocket, command, callback);
 };
 
 SyncHandler.prototype.startSync = function _syncHandleRunSync(ctx, callback) {

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -785,81 +785,107 @@ function _syncHandlerGetZfsProperties(ctx, callback) {
     var self = this;
     var log = self.log;
 
-    // Properties to exclude (read-only, auto-preserved, or encryption-related)
-    var EXCLUDE_PROPERTIES = [
-        // Read-only/computed properties
-        'available', 'compressratio', 'creation', 'clones', 'defer_destroy',
-        'guid', 'logicalreferenced', 'logicalused', 'mounted', 'objsetid',
-        'receive_resume_token', 'referenced', 'refcompressratio', 'type',
-        'used', 'usedbychildren', 'usedbydataset', 'usedbyrefreservation',
-        'usedbysnapshots', 'userrefs', 'written',
-        // Encryption (handled by target CN's encryption key)
-        'encryption', 'encryptionroot', 'keylocation', 'keyformat',
-        'keystatus', 'pbkdf2iters',
-        // Auto-preserved by zfs send/recv
-        'volsize', 'volblocksize'
-    ];
+    // First, check if this is a zoned dataset (delegate dataset)
+    var zonedCmd = '/usr/sbin/zfs';
+    var zonedArgs = ['get', '-H', '-o', 'value', 'zoned', ctx.zfsFilesystem];
 
-    var cmd = '/usr/sbin/zfs';
-    var args = [
-        'get',
-        '-H',
-        '-o', 'property,value,source',
-        '-s', 'local',  // Only locally-set properties
-        'all',
-        ctx.zfsFilesystem
-    ];
-
-    log.debug({cmd: cmd, args: args}, 'getZfsProperties');
-
-    child_process.execFile(cmd, args, gExecFileDefaults,
-            function _execZfsGetPropertiesCb(err, stdout, stderr) {
-        if (err) {
-            log.error({cmd: cmd, args: args},
-                'Error getting zfs properties, err: %s, stderr: %s',
-                err, stderr);
-            callback(err);
+    child_process.execFile(zonedCmd, zonedArgs, gExecFileDefaults,
+            function _execZfsGetZonedCb(zonedErr, zonedStdout, zonedStderr) {
+        if (zonedErr) {
+            log.error({cmd: zonedCmd, args: zonedArgs},
+                'Error getting zoned property, err: %s, stderr: %s',
+                zonedErr, zonedStderr);
+            callback(zonedErr);
             return;
         }
 
-        var lines = String(stdout).trim().split('\n');
-        var properties = {};
+        var isZoned = (String(zonedStdout).trim() === 'on');
 
-        lines.forEach(function _processPropertyLine(line) {
-            if (!line) {
+        // Properties to exclude (read-only, auto-preserved, or encryption-related)
+        var EXCLUDE_PROPERTIES = [
+            // Read-only/computed properties
+            'available', 'compressratio', 'creation', 'clones', 'defer_destroy',
+            'guid', 'logicalreferenced', 'logicalused', 'mounted', 'objsetid',
+            'receive_resume_token', 'referenced', 'refcompressratio', 'type',
+            'used', 'usedbychildren', 'usedbydataset', 'usedbyrefreservation',
+            'usedbysnapshots', 'userrefs', 'written',
+            // Encryption (handled by target CN's encryption key)
+            'encryption', 'encryptionroot', 'keylocation', 'keyformat',
+            'keystatus', 'pbkdf2iters',
+            // Auto-preserved by zfs send/recv
+            'volsize', 'volblocksize'
+        ];
+
+        // For zoned datasets (delegate datasets), also exclude mountpoint
+        // because it cannot be set in a non-global zone
+        if (isZoned) {
+            EXCLUDE_PROPERTIES.push('mountpoint');
+            log.debug({zfsFilesystem: ctx.zfsFilesystem},
+                'Dataset is zoned, excluding mountpoint from properties');
+        }
+
+        var cmd = '/usr/sbin/zfs';
+        var args = [
+            'get',
+            '-H',
+            '-o', 'property,value,source',
+            '-s', 'local',  // Only locally-set properties
+            'all',
+            ctx.zfsFilesystem
+        ];
+
+        log.debug({cmd: cmd, args: args}, 'getZfsProperties');
+
+        child_process.execFile(cmd, args, gExecFileDefaults,
+                function _execZfsGetPropertiesCb(err, stdout, stderr) {
+            if (err) {
+                log.error({cmd: cmd, args: args},
+                    'Error getting zfs properties, err: %s, stderr: %s',
+                    err, stderr);
+                callback(err);
                 return;
             }
 
-            var parts = line.split('\t');
-            if (parts.length < 3) {
-                return;
-            }
+            var lines = String(stdout).trim().split('\n');
+            var properties = {};
 
-            var prop = parts[0];
-            var value = parts[1];
-            var source = parts[2];
+            lines.forEach(function _processPropertyLine(line) {
+                if (!line) {
+                    return;
+                }
 
-            // Skip if in exclude list
-            if (EXCLUDE_PROPERTIES.indexOf(prop) >= 0) {
-                log.trace({property: prop}, 'Skipping excluded property');
-                return;
-            }
+                var parts = line.split('\t');
+                if (parts.length < 3) {
+                    return;
+                }
 
-            // Include the property
-            properties[prop] = value;
-            log.trace({property: prop, value: value, source: source},
-                'Preserving property');
+                var prop = parts[0];
+                var value = parts[1];
+                var source = parts[2];
+
+                // Skip if in exclude list
+                if (EXCLUDE_PROPERTIES.indexOf(prop) >= 0) {
+                    log.trace({property: prop}, 'Skipping excluded property');
+                    return;
+                }
+
+                // Include the property
+                properties[prop] = value;
+                log.trace({property: prop, value: value, source: source},
+                    'Preserving property');
+            });
+
+            ctx.properties = properties;
+
+            log.debug({
+                zfsFilesystem: ctx.zfsFilesystem,
+                propertyCount: Object.keys(properties).length,
+                properties: properties,
+                isZoned: isZoned
+            }, 'getZfsProperties');
+
+            callback();
         });
-
-        ctx.properties = properties;
-
-        log.debug({
-            zfsFilesystem: ctx.zfsFilesystem,
-            propertyCount: Object.keys(properties).length,
-            properties: properties
-        }, 'getZfsProperties');
-
-        callback();
     });
 };
 

--- a/lib/backends/smartos/bin/machine-migrate-send.js
+++ b/lib/backends/smartos/bin/machine-migrate-send.js
@@ -785,107 +785,81 @@ function _syncHandlerGetZfsProperties(ctx, callback) {
     var self = this;
     var log = self.log;
 
-    // First, check if this is a zoned dataset (delegate dataset)
-    var zonedCmd = '/usr/sbin/zfs';
-    var zonedArgs = ['get', '-H', '-o', 'value', 'zoned', ctx.zfsFilesystem];
+    // Properties to exclude (read-only, auto-preserved, or encryption-related)
+    var EXCLUDE_PROPERTIES = [
+        // Read-only/computed properties
+        'available', 'compressratio', 'creation', 'clones', 'defer_destroy',
+        'guid', 'logicalreferenced', 'logicalused', 'mounted', 'objsetid',
+        'receive_resume_token', 'referenced', 'refcompressratio', 'type',
+        'used', 'usedbychildren', 'usedbydataset', 'usedbyrefreservation',
+        'usedbysnapshots', 'userrefs', 'written',
+        // Encryption (handled by target CN's encryption key)
+        'encryption', 'encryptionroot', 'keylocation', 'keyformat',
+        'keystatus', 'pbkdf2iters',
+        // Auto-preserved by zfs send/recv
+        'volsize', 'volblocksize'
+    ];
 
-    child_process.execFile(zonedCmd, zonedArgs, gExecFileDefaults,
-            function _execZfsGetZonedCb(zonedErr, zonedStdout, zonedStderr) {
-        if (zonedErr) {
-            log.error({cmd: zonedCmd, args: zonedArgs},
-                'Error getting zoned property, err: %s, stderr: %s',
-                zonedErr, zonedStderr);
-            callback(zonedErr);
+    var cmd = '/usr/sbin/zfs';
+    var args = [
+        'get',
+        '-H',
+        '-o', 'property,value,source',
+        '-s', 'local',  // Only locally-set properties
+        'all',
+        ctx.zfsFilesystem
+    ];
+
+    log.debug({cmd: cmd, args: args}, 'getZfsProperties');
+
+    child_process.execFile(cmd, args, gExecFileDefaults,
+            function _execZfsGetPropertiesCb(err, stdout, stderr) {
+        if (err) {
+            log.error({cmd: cmd, args: args},
+                'Error getting zfs properties, err: %s, stderr: %s',
+                err, stderr);
+            callback(err);
             return;
         }
 
-        var isZoned = (String(zonedStdout).trim() === 'on');
+        var lines = String(stdout).trim().split('\n');
+        var properties = {};
 
-        // Properties to exclude (read-only, auto-preserved, or encryption-related)
-        var EXCLUDE_PROPERTIES = [
-            // Read-only/computed properties
-            'available', 'compressratio', 'creation', 'clones', 'defer_destroy',
-            'guid', 'logicalreferenced', 'logicalused', 'mounted', 'objsetid',
-            'receive_resume_token', 'referenced', 'refcompressratio', 'type',
-            'used', 'usedbychildren', 'usedbydataset', 'usedbyrefreservation',
-            'usedbysnapshots', 'userrefs', 'written',
-            // Encryption (handled by target CN's encryption key)
-            'encryption', 'encryptionroot', 'keylocation', 'keyformat',
-            'keystatus', 'pbkdf2iters',
-            // Auto-preserved by zfs send/recv
-            'volsize', 'volblocksize'
-        ];
-
-        // For zoned datasets (delegate datasets), also exclude mountpoint
-        // because it cannot be set in a non-global zone
-        if (isZoned) {
-            EXCLUDE_PROPERTIES.push('mountpoint');
-            log.debug({zfsFilesystem: ctx.zfsFilesystem},
-                'Dataset is zoned, excluding mountpoint from properties');
-        }
-
-        var cmd = '/usr/sbin/zfs';
-        var args = [
-            'get',
-            '-H',
-            '-o', 'property,value,source',
-            '-s', 'local',  // Only locally-set properties
-            'all',
-            ctx.zfsFilesystem
-        ];
-
-        log.debug({cmd: cmd, args: args}, 'getZfsProperties');
-
-        child_process.execFile(cmd, args, gExecFileDefaults,
-                function _execZfsGetPropertiesCb(err, stdout, stderr) {
-            if (err) {
-                log.error({cmd: cmd, args: args},
-                    'Error getting zfs properties, err: %s, stderr: %s',
-                    err, stderr);
-                callback(err);
+        lines.forEach(function _processPropertyLine(line) {
+            if (!line) {
                 return;
             }
 
-            var lines = String(stdout).trim().split('\n');
-            var properties = {};
+            var parts = line.split('\t');
+            if (parts.length < 3) {
+                return;
+            }
 
-            lines.forEach(function _processPropertyLine(line) {
-                if (!line) {
-                    return;
-                }
+            var prop = parts[0];
+            var value = parts[1];
+            var source = parts[2];
 
-                var parts = line.split('\t');
-                if (parts.length < 3) {
-                    return;
-                }
+            // Skip if in exclude list
+            if (EXCLUDE_PROPERTIES.indexOf(prop) >= 0) {
+                log.trace({property: prop}, 'Skipping excluded property');
+                return;
+            }
 
-                var prop = parts[0];
-                var value = parts[1];
-                var source = parts[2];
-
-                // Skip if in exclude list
-                if (EXCLUDE_PROPERTIES.indexOf(prop) >= 0) {
-                    log.trace({property: prop}, 'Skipping excluded property');
-                    return;
-                }
-
-                // Include the property
-                properties[prop] = value;
-                log.trace({property: prop, value: value, source: source},
-                    'Preserving property');
-            });
-
-            ctx.properties = properties;
-
-            log.debug({
-                zfsFilesystem: ctx.zfsFilesystem,
-                propertyCount: Object.keys(properties).length,
-                properties: properties,
-                isZoned: isZoned
-            }, 'getZfsProperties');
-
-            callback();
+            // Include the property
+            properties[prop] = value;
+            log.trace({property: prop, value: value, source: source},
+                'Preserving property');
         });
+
+        ctx.properties = properties;
+
+        log.debug({
+            zfsFilesystem: ctx.zfsFilesystem,
+            propertyCount: Object.keys(properties).length,
+            properties: properties
+        }, 'getZfsProperties');
+
+        callback();
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cn-agent",
   "description": "Triton Compute Node Agent",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes https://github.com/TritonDataCenter/sdc-vmapi/issues/92 - Enables VM migration from encrypted compute nodes to other CNs (encrypted or unencrypted).

## AI Disclosure
@claude provided substantial assistance in the development of this PR.

## Problem

VM instances on encrypted compute nodes could not be migrated because:
1. `zfs send --replicate` includes properties in the stream
2. Encrypted datasets cannot send properties without the `--raw` flag
3. `--raw` is incompatible because each CN has a unique encryption key (via YubiKey)

Error encountered:
```
cannot send zones/3d583590-c8ff-cd0d-e0b4-c3e439208fe6@vm-migration-1: encrypted dataset zones/3d583590-c8ff-cd0d-e0b4-c3e439208fe6 may not be sent with properties without the raw flag
```
## Solution

Modified migration to detect encryption and handle encrypted datasets differently:

1. **Encryption detection**: Check each dataset's `encryption` property
2. **Child dataset discovery**: For encrypted datasets, discover and migrate child datasets individually (since `--replicate` can't be used)
3. **Manual property handling**: Collect properties with sources `local` and `received`, then send them separately
4. **Property timing**: Only send properties on first sync (initial dataset creation), not on incremental syncs to avoid "mountpoint cannot be set on dataset in a non-global zone" errors
5. **Origin handling**: For datasets cloned from images, import the origin image on the target and use incremental sends

## Key Changes

**lib/backends/smartos/bin/machine-migrate-send.js:**
- Added `checkZfsEncryption()` - detect if dataset is encrypted
- Added `discoverAllChildDatasets()` - recursively discover child datasets (only for encrypted)
- Added `getZfsProperties()` - collect properties with sources `local,received` (only for encrypted)
- Added `getZfsOrigin()` - detect image-based datasets
- Added `ensureOriginImageOnTarget()` - ensure origin images exist on target
- Modified `getZfsSyncArgs()` - skip `--replicate` for encrypted datasets
- Modified `setupSync()` - only send properties on first sync (not incremental)
- Comprehensive property exclusions (read-only, encryption-related, auto-preserved)

**lib/backends/smartos/bin/machine-migrate-receive.js:**
- Added `commandImportImage()` - import origin images via imgadm
- Modified `zfsSyncReceive()` - apply properties using `-o` flags during receive

**package.json:**
- Version bump: 2.15.0 → 2.15.1

## Migration Behavior

**Unencrypted datasets (existing behavior preserved):**
- Uses `zfs send --replicate` (efficient, includes children and properties)
- No child discovery needed
- No manual property collection needed
- Single send operation per top-level dataset

**Encrypted datasets (new behavior):**
- Skips `--replicate` flag
- Discovers all child datasets individually
- Collects properties with `-s local,received`
- Excludes read-only and encryption-related properties
- Sends properties via `-o` flags on first sync only
- Handles origin-based datasets with incremental sends

## Testing

Tested all migration scenarios:

| Source       | Target       | Result |
|--------------|--------------|--------|
| Encrypted    | Unencrypted  | ✅ Pass |
| Unencrypted  | Encrypted    | ✅ Pass |
| Encrypted    | Encrypted    | ✅ Pass |
| Unencrypted  | Unencrypted  | ✅ Pass |

**Verified:**
- Properties preserved (quota, recordsize, mountpoint, custom properties)
- Child datasets migrated correctly
- Mountpoints preserved on delegate datasets (zoned=on)
- Origin-based datasets (cloned from images) handled correctly
- Both first sync and incremental syncs complete successfully